### PR TITLE
feat(movies): adds functionality for adding movies to database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ node_js:
 env:
   - NODE_ENV='test'
 before_script:
-  - createuser sfmovies_user
-  - createdb -O sfmovies_user sfmovies_test
-  - npm run db:migrate
+  - npm run db:setup:user
+  - npm run db:reset
 script:
   - npm test
   - npm run enforce

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = (payload) => {
+  return new Movie().save(payload)
+  .then((movie) => {
+    return new Movie({ id: movie.id }).fetch();
+  });
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Controller     = require('./controller');
+const MovieValidator = require('../../../validators/movie');
+
+exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.create(request.payload));
+      },
+      validate: {
+        payload: MovieValidator
+      }
+    }
+  }]);
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,8 +13,14 @@ const server = new Hapi.Server({
 server.connection({ port: Config.PORT });
 
 server.register([
-  require('hapi-bookshelf-serializer')
+  require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
+  require('./plugins/features/movies')
 ], (err) => {
+  /* istanbul ignore if */
   if (err) {
     throw err;
   }

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().min(1878).max(9999).optional()
+});

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -944,6 +944,11 @@
       "from": "hapi-bookshelf-serializer@*",
       "resolved": "https://registry.npmjs.org/hapi-bookshelf-serializer/-/hapi-bookshelf-serializer-2.1.0.tgz"
     },
+    "hapi-format-error": {
+      "version": "1.0.0",
+      "from": "hapi-format-error@*",
+      "resolved": "https://registry.npmjs.org/hapi-format-error/-/hapi-format-error-1.0.0.tgz"
+    },
     "har-validator": {
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
@@ -1144,6 +1149,11 @@
       "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
+    "isemail": {
+      "version": "2.1.2",
+      "from": "isemail@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.1.2.tgz"
+    },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
@@ -1201,6 +1211,18 @@
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+    },
+    "joi": {
+      "version": "8.1.1",
+      "from": "joi@*",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-8.1.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.0",
+          "from": "hoek@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.0.tgz"
+        }
+      }
     },
     "js-yaml": {
       "version": "3.4.5",
@@ -1579,6 +1601,11 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
+    },
+    "moment": {
+      "version": "2.13.0",
+      "from": "moment@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
@@ -2097,6 +2124,17 @@
       "version": "0.0.2",
       "from": "to-iso-string@0.0.2",
       "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz"
+    },
+    "topo": {
+      "version": "2.0.1",
+      "from": "topo@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.0",
+          "from": "hoek@>=4.0.0 <5.0.0"
+        }
+      }
     },
     "touch": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "scripts": {
     "db:migrate": "knex migrate:latest --knexfile db/index.js",
     "db:migrate:make": "knex migrate:make --knexfile db/index.js",
-    "db:reset": "dropdb sfmovies_development; createdb -O sfmovies_user sfmovies_development && npm run db:migrate",
+    "db:reset": "if [ \"$NODE_ENV\" != \"production\" ]; then dropdb $(node -p \"require('./config').DB_NAME\"); npm run db:setup && npm run db:migrate; fi",
     "db:rollback": "knex migrate:rollback --knexfile db/index.js",
+    "db:setup": "if [ \"$NODE_ENV\" != \"production\" ]; then createdb -O $(node -e \"var c = require('./config'); console.log(c.DB_USER, c.DB_NAME);\"); fi",
+    "db:setup:user": "if [ \"$NODE_ENV\" != \"production\" ]; then createuser $(node -p \"require('./config').DB_USER\"); fi",
     "db:seed": "npm run db:reset && knex seed:run --knexfile db/index.js",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint .",
@@ -32,6 +34,8 @@
     "bookshelf": "^0.9.5",
     "hapi": "^13.4.1",
     "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.0.0",
+    "joi": "^8.1.1",
     "knex": "^0.11.5",
     "pg": "^4.5.5"
   },

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
+
+describe('movie controller', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      const payload = {
+        title: 'Inception',
+        release_year: 2010
+      };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('release_year')).to.eql(payload.release_year);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('release_year')).to.eql(payload.release_year);
+      });
+    });
+
+  });
+
+});

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is not empty', () => {
+      const payload = { title: '' };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.empty');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(260) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1800
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});


### PR DESCRIPTION
What: Lets users add movies to the database by sending a POST HTTP request.

Why: We want users to be able to add new movies so we can keep track of movies that are not already in our database.

Details:
- `movies` plugin, validator, and controller added.
- Tests for the `movies` validator and controller added in the `tests` folder.
